### PR TITLE
IOM-517

### DIFF
--- a/src/helpers/generic.js
+++ b/src/helpers/generic.js
@@ -25,8 +25,8 @@ export function formatMapData(data, activityCount, budgetValue) {
 }
 
 //Adds values from the oldFIlters to the new ones
-//Used for donor-group/donor detail pages
-//Cause it was requested for filters from the donors page to be applied to those ^ pages as well
+// It was requested that overview pages filters would be applied to their drill downs/detail pages
+//Except Projects, projects filters should only be applied for the Project overview page
 export function addFilterValues(oldFilters, filterValuez) {
     const filterValues = filterValuez;
     for (let key in oldFilters){

--- a/src/scenes/countries/components/CountriesTable.js
+++ b/src/scenes/countries/components/CountriesTable.js
@@ -46,7 +46,12 @@ class CountriesTable extends BaseFilter {
       dataIndex: 'recipient_country',
       key: 'recipient_country',
       render: recipient_country =>
-        <Link to={`/countries/${recipient_country.code.toLowerCase()}`}>{recipient_country.name}</Link>,
+        <Link to={{
+            pathname: `/countries/${recipient_country.code.toLowerCase()}`,
+            state: { filterValues: filters.values }
+        }}>
+            {recipient_country.name}
+        </Link>
     }, {
       title: <SortHeader
               title={intl.formatMessage({id: 'countries.table.budget', defaultMessage: 'Budget'})}

--- a/src/scenes/country/Country.js
+++ b/src/scenes/country/Country.js
@@ -18,8 +18,8 @@ import ContactProject from './components/ContactProject';
 import SectorsMap from './components/SectorsMap';
 import { pageContainer } from '../../helpers/style';
 import CountriesJSON from '../../services/data/countries.json';
-import GeoMap from "../../components/maps/GeoMap";
-import { formatMapData } from "../../helpers/generic";
+import GeoMap from '../../components/maps/GeoMap';
+import { addFilterValues, formatMapData } from '../../helpers/generic';
 
 class Country extends BaseFilter {
   componentDidMount() {
@@ -28,6 +28,13 @@ class Country extends BaseFilter {
     const code = get(this.props, 'match.params.code');
     if (dispatch && code) {
       if (params) {
+        if(this.props.location.state)
+        {
+            //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+            // 'params' works as a reference when passed in this function
+            addFilterValues(this.props.location.state.filterValues, params);
+            console.log(params);
+        }
         this.actionRequest(
           extend({}, params, {recipient_country: code.toUpperCase()}),
           'recipient_country',
@@ -86,7 +93,7 @@ class Country extends BaseFilter {
     ];
 
     const countryData = get(countryResult, 'recipient_country');
-
+    const prevFilters = this.props.location.state ? this.props.location.state.filterValues : false;
     return (
       <Spin spinning={country.request || countryDonors.request || countryActivities.request || countrySectors.request || project.request}>
         <Page breadcrumbItems={breadcrumbItems}>
@@ -127,7 +134,8 @@ class Country extends BaseFilter {
                 <h2 className="title">
                   <Trans id="country.table.projects.title" defaultMessage="Related projects"/>
                 </h2>
-                <TableProjects countryCode={ get(this.props, 'match.params.code')} itemAmount={7} />
+                <TableProjects countryCode={ get(this.props, 'match.params.code')}
+                               itemAmount={7} filterValues={prevFilters}/>
               </Col>
             </Row>
             {firstProject ? <ContactProject id={firstProject.id} code={get(this.props, 'match.params.code')} /> : null}

--- a/src/scenes/country/components/TableProjects.js
+++ b/src/scenes/country/components/TableProjects.js
@@ -1,16 +1,17 @@
 import React, {Component, Fragment} from 'react';
 import Table from 'antd/es/table';
 import injectSheet from 'react-jss';
-import { injectIntl, intlShape } from "react-intl";
-import {connect} from "react-redux";
+import { injectIntl, intlShape } from 'react-intl';
+import {connect} from 'react-redux';
 import get from 'lodash/get';
 import { format } from 'd3-format';
 import { Link } from 'react-router-dom';
 
-import * as actions from "../../../services/actions/index";
-import SortHeader from "../../../components/SortHeader/SortHeader";
-import Pagination from "../../../components/Pagination/Pagination";
-import {paginate} from "../../../helpers/tableHelpers";
+import * as actions from '../../../services/actions/index';
+import SortHeader from '../../../components/SortHeader/SortHeader';
+import Pagination from '../../../components/Pagination/Pagination';
+import { paginate } from '../../../helpers/tableHelpers';
+import { addFilterValues } from '../../../helpers/generic';
 
 class TableProjects extends Component {
   constructor(props) {
@@ -38,6 +39,12 @@ class TableProjects extends Component {
   getProjects() {
     const { dispatch } = this.props;
     const { params } = this.state;
+    if(this.props.filterValues)
+    {
+        //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+        // params works as a reference when passed in this function
+        addFilterValues(this.props.filterValues, params);
+    }
     if (dispatch) {
       if (params) {
         dispatch(actions.countryActivitiesRequest(params));
@@ -148,7 +155,7 @@ class TableProjects extends Component {
       const data = paginate(this.state.page, this.state.pageSize, allData);
     return(
         <Fragment>
-            <Table dataSource={data ? this.addKey(data) : null} columns={columns} size="middle"
+            <Table dataSource={data ? this.addKey(data) : null} columns={columns} size='middle'
                    pagination={false}
                    scroll={{ x: 1800 }}
                    loading={countryActivities.request}

--- a/src/scenes/donor/Donor.js
+++ b/src/scenes/donor/Donor.js
@@ -45,6 +45,7 @@ class Donor extends BaseFilter {
       },
       {url: null, text: data ? data.participating_organisation : <Trans id='main.menu.detail' text='Detail' />},
     ] : null;
+    const prevFilters = this.props.location.state ? this.props.location.state.filterValues : false;
     return (
       <Page breadcrumbItems={breadcrumbItems}>
         <Grid style={pageContainer} fluid>
@@ -56,7 +57,7 @@ class Donor extends BaseFilter {
           <hr className={classes.divider} />
           <Row className={classes.table}>
             <Col xs={12}>
-              <DonorProjects code={code} filterValues={this.props.location.state.filterValues}/>
+              <DonorProjects code={code} filterValues={prevFilters}/>
             </Col>
           </Row>
         </Grid>

--- a/src/scenes/donor/components/DonorProjects.js
+++ b/src/scenes/donor/components/DonorProjects.js
@@ -40,9 +40,11 @@ class DonorProjects extends Component {
   getProjects() {
     const { dispatch } = this.props;
     const { params } = this.state;
-    //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
-      // params works as a reference when passed in this function
-    addFilterValues(this.props.filterValues, params);
+    if(this.props.filterValues){
+        //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+        // params works as a reference when passed in this function
+        addFilterValues(this.props.filterValues, params);
+    }
     if (dispatch) {
       if (params) {
         dispatch(actions.donorProjectsRequest(params));

--- a/src/scenes/projects/Projects.js
+++ b/src/scenes/projects/Projects.js
@@ -35,19 +35,18 @@ class Projects extends BaseFilter {
   }
 
   countriesRequest() {
-    const { filters, dataRange } = this.state;
+    const { filters } = this.state;
     const params = {
       aggregations: 'activity_count,incoming_fund,disbursement,value',
       group_by: '',
       order_by: '-value',
       reporting_organisation_identifier: process.env.REACT_APP_REPORTING_ORGANISATION_IDENTIFIER
     };
-    const filterDataRange = dataRange ? {total_budget_gte: dataRange[0], total_budget_lte: dataRange[1]} : {};
     this.actionRequest(
-      extend({}, params, filters.values, filterDataRange), 'recipient_country', actions.countriesRequest
+      extend({}, params, filters.values), 'recipient_country', actions.countriesRequest
     );
     this.actionRequest(
-      extend({}, params, filters.values, filterDataRange), 'participating_organisation', actions.countryDonorsRequest
+      extend({}, params, filters.values), 'participating_organisation', actions.countryDonorsRequest
     );
   }
 
@@ -55,10 +54,10 @@ class Projects extends BaseFilter {
     if (prevState !== this.state) {
       this.countriesRequest();
       if (prevState.dataRange !== this.state.dataRange) {
-        const { params, filters, dataRange } = this.state;
+        const { params, filters } = this.state;
         delete filters.values['page'];
         this.actionRequest(
-          extend({}, params, filters.values, {total_budget_gte: dataRange[0], total_budget_lte: dataRange[1]}),
+          extend({}, params, filters.values),
           null,
           actions.projectsRequest
         );

--- a/src/scenes/service/Service.js
+++ b/src/scenes/service/Service.js
@@ -15,7 +15,8 @@ import ServiceDonors from './components/ServiceDonors';
 import ServiceProjects from './components/ServiceProjects';
 import ServiceCountries from './components/ServiceCountries';
 import ServicesJSON from '../../services/data/services';
-import find from "lodash/find";
+import find from 'lodash/find';
+import { addFilterValues } from '../../helpers/generic';
 
 class Service extends BaseFilter {
   componentDidMount() {
@@ -23,6 +24,11 @@ class Service extends BaseFilter {
     const { params } = this.state;
     const id = get(this.props, 'match.params.id');
     if (dispatch && id) {
+        if(this.props.location.state){
+            //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+            // params works as a reference when passed in this function
+            addFilterValues(this.props.location.state.filterValues, params);
+        }
       this.actionRequest(extend({}, params, {sector: id}), 'sector', actions.serviceRequest);
     } else {
       actions.serviceInitial();
@@ -40,6 +46,7 @@ class Service extends BaseFilter {
     ];
     const code = get(this.props, 'match.params.id');
     const serviceJSON = find(ServicesJSON, {'code': code.toUpperCase()});
+    const prevFilters = this.props.location.state ? this.props.location.state.filterValues : false;
     return (
       <Spin spinning={service.request || serviceProjects.request}>
         <Page breadcrumbItems={breadcrumbItems}>
@@ -47,13 +54,13 @@ class Service extends BaseFilter {
           <Grid className={classes.service} fluid>
             <Row xs={12} lg={6}>
               <Col xs={12} lg={6} className={classes.listsContainer}>
-                <ServiceDonors sectorId={sectorId} />
-                <ServiceProjects sectorId={sectorId} />
+                <ServiceDonors sectorId={sectorId} filterValues={prevFilters}/>
+                <ServiceProjects sectorId={sectorId} filterValues={prevFilters}/>
               </Col>
             </Row>
             <Row className="map-row">
               <Col xs={12}>
-                <ServiceCountries sectorId={sectorId} />
+                <ServiceCountries sectorId={sectorId} filterValues={prevFilters}/>
               </Col>
             </Row>
           </Grid>

--- a/src/scenes/service/components/ServiceCountries.js
+++ b/src/scenes/service/components/ServiceCountries.js
@@ -8,6 +8,7 @@ import BaseFilter from '../../../components/base/filters/BaseFilter';
 import * as actions from '../../../services/actions';
 import GeoMap from '../../../components/maps/GeoMap';
 import Trans from '../../../locales/Trans';
+import {addFilterValues} from "../../../helpers/generic";
 
 class ServiceCountries extends BaseFilter {
   componentDidMount() {
@@ -15,6 +16,12 @@ class ServiceCountries extends BaseFilter {
     const { params } = this.state;
     if (dispatch) {
       if (params) {
+          if(this.props.filterValues)
+          {
+              //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+              // params works as a reference when passed in this function
+              addFilterValues(this.props.filterValues, params);
+          }
         this.actionRequest(
           extend({}, params, {sector: sectorId}), 'recipient_country', actions.serviceCountriesRequest
         );

--- a/src/scenes/service/components/ServiceDonors.js
+++ b/src/scenes/service/components/ServiceDonors.js
@@ -9,6 +9,7 @@ import injectSheet from "react-jss";
 import { Link } from 'react-router-dom';
 import SortHeader from "../../../components/SortHeader/SortHeader";
 import Pagination from "../../../components/Pagination/Pagination";
+import {addFilterValues} from "../../../helpers/generic";
 
 
 class ServiceDonors extends React.Component {
@@ -56,6 +57,12 @@ class ServiceDonors extends React.Component {
     const { dispatch, sectorId } = this.props;
     const { params } = this.state;
     if (dispatch && sectorId) {
+        if(this.props.filterValues)
+        {
+            //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+            // params works as a reference when passed in this function
+            addFilterValues(this.props.filterValues, params);
+        }
       dispatch(actions.serviceDonorsRequest({ ...params, sector: sectorId }));
     } else {
       dispatch(actions.serviceDonorsInitial());

--- a/src/scenes/service/components/ServiceProjects.js
+++ b/src/scenes/service/components/ServiceProjects.js
@@ -6,6 +6,7 @@ import get from 'lodash/get';
 
 import BaseFilter from '../../../components/base/filters/BaseFilter';
 import ProjectsTable from '../components/ProjectsTable';
+import {addFilterValues} from "../../../helpers/generic";
 
 class ServiceProjects extends BaseFilter {
   constructor(props) {
@@ -40,6 +41,12 @@ class ServiceProjects extends BaseFilter {
     const { params } = this.state;
     if (dispatch) {
       if (params) {
+          if(this.props.filterValues)
+          {
+              //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+              // params works as a reference when passed in this function
+              addFilterValues(this.props.filterValues, params);
+          }
         dispatch(actions.serviceProjectsRequest(params));
       } else {
         dispatch(actions.serviceProjectsInitial());

--- a/src/scenes/services/ServicesHelper.js
+++ b/src/scenes/services/ServicesHelper.js
@@ -21,6 +21,7 @@ export function combineData(human, nonHuman) {
             let nonHumanItem = nonHuman[j];
             if(humanItem.sector.code === nonHumanItem.sector.code){
               let item = humanItem;
+              item.activity_count = humanItem.activity_count + nonHumanItem.activity_count;
               item.nonHumanValue = nonHumanItem.value;
               data.push(item);
               //So if a human and nonhuman data association is found we give the nonHuman item

--- a/src/scenes/services/components/ServicesTable.js
+++ b/src/scenes/services/components/ServicesTable.js
@@ -47,7 +47,12 @@ class ServicesTable extends BaseFilter {
       key: 'sector',
       width: '55%',
       render: (name, record) =>
-        <Link to={`/services/${record.sector.code}`}>{name}</Link>,
+        <Link to={{
+            pathname: `/services/${record.sector.code}`,
+            state: { filterValues: filters.values }
+        }}>
+            {name}
+        </Link>
     },
       {
       title: <SortHeader


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/IOM-517

Implement stickies filters

Oke so the filters aplied on Sevices overview page and Countries overview page should also be applied in Service detail page and Countries detail page. For all data shown there. Projects filters should only be applied for the Projects overview page(NOT the project detail). And the donors filters have already been covered properly here -  IOM-513 DONE  , so no adjustments 

ALSO:
1) Also added some fixes to donors to when a link is opened in a new tab, or if the url would be posted directly into the address bar. (Filters should not be applied then). applied the same check for other drill downs.
2) Also fixed the filtering issues for the services overview page. (The non humanitarian project count would not be applied in the list).
3) The funding amount filter has not been applied to the drill downs of overview pages, because it is not set up to work with the backend. As well as other data in the overview pages details are not set up to work with the budget filter. 
4) There's also a bug because of this funding amount filter, where the project count for some services increases whenever this funding amount filter is used, this would be fixed by implementing a backend budget filter.