### PR TITLE
IOM-565

### DIFF
--- a/src/components/maps/GeoMap.js
+++ b/src/components/maps/GeoMap.js
@@ -202,7 +202,7 @@ class GeoMap extends Component {
       layer.bindPopup(tooltipContent);
 
       layer.on("mouseover", function(e) {
-        this.openPopup();
+        this.openPopup(e.latlng);
       });
 
         if(this.props.detail)


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/IOM-565

Bad country tooltip positioning. Currently the tool tip for some countries appear on an island belonging to the country and not on the center of the main land mass. So if possible center it on the main land mass(hence the biggest polygon). If not possible, then apply a new tooltip that moves with the mouse, should solve the issue.

See - https://iom-staging.zz-demos.net/countries/AU

So now the tooltip appears at the hovered lng lat position.