### PR TITLE
IOM-525

### DIFF
--- a/src/scenes/home/components/HomeChart.js
+++ b/src/scenes/home/components/HomeChart.js
@@ -181,7 +181,7 @@ const styles = {
       maxWidth: '100%',
       fontSize: 21,
         fontWeight: 500,
-      lineHeight: 1.33,
+      lineHeight: 1.3,
       '@media only screen and (max-width: 767px)': {
         fontSize: 15,
       }


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/IOM-525

Screen resolution changes only change the text not the donut.

Scaling is also a tad off depending upon the resolution whereby text string that takes up two lines with characters that go below the line (g, y, p). The part below the line gets cut off for the boxes at the bottom of the list.
![screen shot 2018-11-05 at 14 22 36](https://user-images.githubusercontent.com/11508354/48616682-ff2b5500-e99c-11e8-9f68-3de1a3aae40f.png)
