### PR TITLE
IOM-585

### DIFF
--- a/src/scenes/service/components/ServiceDonors.js
+++ b/src/scenes/service/components/ServiceDonors.js
@@ -59,9 +59,12 @@ class ServiceDonors extends React.Component {
     if (dispatch && sectorId) {
         if(this.props.filterValues)
         {
+            const filterValues = this.props.filterValues;
+            filterValues.participating_organisation_ref = filterValues.participating_organisation;
+            delete filterValues['participating_organisation'];
             //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
             // params works as a reference when passed in this function
-            addFilterValues(this.props.filterValues, params);
+            addFilterValues(filterValues, params);
         }
       dispatch(actions.serviceDonorsRequest({ ...params, sector: sectorId }));
     } else {


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/IOM-585

Service filtering by donor drill down not working *See attachment simplescreenrecorder-2018-11-22_17.44.17.mkv *.

Basically this api call - http://iom-oipa-dev.zz-demos.net/api/budgets/aggregations/?aggregations=activity_count%2Cincoming_fund%2Cdisbursement%2Cexpenditure%2Cvalue&group_by=sector&order_by=-value&hierarchy=1&reporting_organisation_identifier=XM-DAC-47066&participating_organisation=GB-COH-01846493&page=1&sector=1%2C2%2C3%2C4%2C5%2C6%2C7&format=json returns services when filtering by 'participating_organisation_ref=GB-COH-01846493'. 
But this api call doesn't retrieve the donors with the specified participating_organisation_ref and the sector - http://iom-oipa-dev.zz-demos.net/api/transactions/aggregations/?aggregations=activity_count%2Cincoming_fund%2Cdisbursement%2Cexpenditure%2Cvalue&group_by=participating_organisation&reporting_organisation_identifier=XM-DAC-47066&order_by=participating_organisation&page=1&page_size=5&sector%20type=1%2C2%2C3%2C4%2C5%2C6%2C7&participating_organisation=GB-COH-01846493&sector=1&format=json

ye so just adjusted the api parameters on the frontend