### PR TITLE
IOM-596

### DIFF
--- a/src/components/maps/GeoMap.js
+++ b/src/components/maps/GeoMap.js
@@ -20,8 +20,11 @@ import {connect} from "react-redux";
 import GenericDialog from "../dialogWindow/GenericDialog/GenericDialog";
 import MapToolTip from "./MapToolTip/MapToolTip";
 
+//Yellowish
+// const colors = ["rgb(255, 244, 221)", "rgb(255, 220, 142)", "rgb(255, 184,28)"];
 
-const colors = ["#CDDC39", "#4CAF50", "#795548"];
+//Orange'ish
+const colors = ["rgb(255, 232, 221)",  "rgb(255, 179, 143)", "rgb(255, 103, 31)"];
 
 class GeoMap extends Component {
   constructor(props) {
@@ -188,7 +191,7 @@ class GeoMap extends Component {
       .range(colors);
 
     layer.setStyle({
-      fillOpacity: 0.6,//0.2 + (feature.properties.value / this.state.maxValue * 0.6),
+      fillOpacity: 0.8,//0.2 + (feature.properties.value / this.state.maxValue * 0.6),
       fillColor: getColor(feature.properties.value)
     });
     // TODO: value is project_amount or value


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/IOM-596

Please use the yellow family of secondary colors from the official IOM color palette to fill in countries on the maps. There are five options per color which will match the five graded values displayed.

**Morty's notes**: Used the orange colors, cause the yellow ones seem to merge with the white default color of the map.
Also increased the opacity, so that layers would be easier to see.
