### PR TITLE
IOM-626 IOM-627

### DIFF
--- a/src/scenes/project/Project.js
+++ b/src/scenes/project/Project.js
@@ -28,7 +28,7 @@ class Project extends Component {
     const data = get(this.props.project, 'data', null);
     const breadcrumbItems = [
       {url: '/', text: <Trans id='main.menu.home' text='Home' />},
-      {url: '/countries', text: <Trans id='main.menu.projects' text='Projects' />},
+      {url: '/projects', text: <Trans id='main.menu.projects' text='Projects' />},
       {url: null, text: <Trans id='main.menu.detail' text='Detail' />},
     ];
     return(

--- a/src/scenes/service/Service.js
+++ b/src/scenes/service/Service.js
@@ -25,17 +25,39 @@ class Service extends BaseFilter {
     const { params } = this.state;
     const id = get(this.props, 'match.params.id');
     if (dispatch && id) {
-        if(this.props.location.state){
-            //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
-            // params works as a reference when passed in this function
-            addFilterValues(this.props.location.state.filterValues, params);
-        }
+      if(this.props.location.state){
+        //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+        // params works as a reference when passed in this function
+        addFilterValues(this.props.location.state.filterValues, params);
+      }
       this.actionRequest(extend({}, params, {sector: id}), 'sector', actions.serviceRequest);
-        if(!donorGroupJson.data) {
-            dispatch(actions.donorGroupJsonRequest(donorGroupJsonSlug));
-        }
+      if(!donorGroupJson.data) {
+        dispatch(actions.donorGroupJsonRequest(donorGroupJsonSlug));
+      }
     } else {
       actions.serviceInitial();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { dispatch, donorGroupJson, donorGroupJsonSlug } = this.props;
+    const { params } = this.state;
+    const id = get(this.props, 'match.params.id');
+    const prevId = get(prevProps, 'match.params.id');
+    if (prevId !== id) {
+      if (dispatch && id) {
+        if(this.props.location.state){
+          //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+          // params works as a reference when passed in this function
+          // addFilterValues(this.props.location.state.filterValues, params);
+        }
+        this.actionRequest(extend({}, params, {sector: id}), 'sector', actions.serviceRequest);
+        if(!donorGroupJson.data) {
+          dispatch(actions.donorGroupJsonRequest(donorGroupJsonSlug));
+        }
+      } else {
+        actions.serviceInitial();
+      }
     }
   }
 
@@ -48,7 +70,7 @@ class Service extends BaseFilter {
         <Trans id='services.breadcrumb.service.detail' text='Service area detail page' />;
     const breadcrumbItems = [
       {url: '/', text: <Trans id='main.menu.home' text='Home' />},
-      {url: '/countries', text: <Trans id='main.menu.services' text='Our Service' />},
+      {url: '/services', text: <Trans id='main.menu.services' text='Our Service' />},
       {url: null, text: currentBreadTxt},
     ];
     const code = get(this.props, 'match.params.id');
@@ -68,7 +90,7 @@ class Service extends BaseFilter {
                       <ServiceProjects sectorId={sectorId} filterValues={prevFilters}/> :
                   <div className={classes.twoLists}>
                     <ServiceDonors sectorId={sectorId} filterValues={prevFilters} donorGroupJson={get(donorGroupJson, 'data.content', {})} />
-                    <ServiceProjectTypes serviceId={sectorId} />
+                    <ServiceProjectTypes serviceId={sectorId} filterValues={prevFilters} />
                   </div>
                   }
               </Col>

--- a/src/scenes/service/components/ServiceCountries.js
+++ b/src/scenes/service/components/ServiceCountries.js
@@ -31,6 +31,27 @@ class ServiceCountries extends BaseFilter {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { dispatch, sectorId } = this.props;
+    const { params } = this.state;
+    if (prevProps.sectorId !== sectorId) {
+      if (dispatch) {
+        if (params) {
+          if (this.props.filterValues) {
+              //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+              // params works as a reference when passed in this function
+              addFilterValues(this.props.filterValues, params);
+          }
+          this.actionRequest(
+            extend({}, params, {sector: sectorId}), 'recipient_country', actions.serviceCountriesRequest
+          );
+        } else {
+          dispatch(actions.serviceCountriesInitial());
+        }
+      }
+    }
+  }
+
   render() {
     const { serviceCountries, classes } = this.props;
     const data = get(serviceCountries, 'data.results');

--- a/src/scenes/service/components/ServiceProjectTypes.js
+++ b/src/scenes/service/components/ServiceProjectTypes.js
@@ -13,6 +13,7 @@ import Pagination from "../../../components/Pagination/Pagination";
 import * as actions from "../../../services/actions";
 import BaseFilter from "../../../components/base/filters/BaseFilter";
 import { genericSort, paginate } from "../../../helpers/tableHelpers";
+import {addFilterValues} from "../../../helpers/generic";
 
 class ServiceProjectTypes extends BaseFilter {
 
@@ -23,6 +24,16 @@ class ServiceProjectTypes extends BaseFilter {
         const serviceAreas = get(sectorMapping, 'data.content.serviceAreaFilter');
         const serviceProjectTypes = dacSectors[serviceId] ? dacSectors[serviceId] : serviceAreas[serviceId];
         if (dispatch) {
+            if(this.props.filterValues){
+                const filterValues = this.props.filterValues;
+                if (filterValues.participating_organisation_ref) {
+                    filterValues.participating_organisation = filterValues.participating_organisation_ref;
+                    delete filterValues['participating_organisation_ref'];
+                }
+                //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
+                // params works as a reference when passed in this function
+                addFilterValues(filterValues, params);
+            }
             params.humanitarian = 1;
             this.actionRequest({
                 ...params,
@@ -75,7 +86,7 @@ class ServiceProjectTypes extends BaseFilter {
                 />,
             dataIndex: 'sector',
             render: sector =>
-                <Link to={`/services/project-type/${sector.code}`}>{sector.name}</Link>
+                <Link to={{ pathname: `/services/project-type/${sector.code}`, state: { filterValues: this.props.filterValues }}}>{sector.name}</Link>
         }, {
             title: <SortHeader
                 title={intl.formatMessage({id: 'service.project.types.funding', defaultMessage: 'Total funding value'})}

--- a/src/scenes/service/components/ServiceProjects.js
+++ b/src/scenes/service/components/ServiceProjects.js
@@ -41,8 +41,12 @@ class ServiceProjects extends BaseFilter {
     const { params } = this.state;
     if (dispatch) {
       if (params) {
-          if(this.props.filterValues)
-          {
+          if(this.props.filterValues){
+              const filterValues = this.props.filterValues;
+              if (filterValues.participating_organisation_ref) {
+                filterValues.participating_organisation = filterValues.participating_organisation_ref;
+                delete filterValues['participating_organisation_ref'];
+              }
               //NOTE! this fucntion actually changes the states variable WITHOUT calling this.setState()
               // params works as a reference when passed in this function
               addFilterValues(this.props.filterValues, params);


### PR DESCRIPTION
https://zimmermanzimmerman.atlassian.net/browse/IOM-626
https://zimmermanzimmerman.atlassian.net/browse/IOM-627

IOM-626 | Navigating to a project type page from service detail page bug
Steps to reproduce:

Go to https://iom-staging.zz-demos.net/services/1
Click on a project type link under "Where the funds go" table
Check the page header => still the service name
then:

If refresh, page header updates ok.
Go back with browser back button
Check the page header => still the project type name

IOM-627 | Filter is not applied for the project type list in service detail page.
Filter is not applied for the project type list in service detail page. 
1) go to our services page.
2) Apply the geolocation filter 'Afghanistan'
3) Go to the service area in the list
Verify that the project type list is the same as if the filter was not applied

Notes:
- Fixed issues mentioned above
- Fixed breadcrumb links in service and project detail page